### PR TITLE
Refactors simples

### DIFF
--- a/app/src/main/java/com/coffeeandcookies/pokemondaywidget/MyAppWidgetProvider.kt
+++ b/app/src/main/java/com/coffeeandcookies/pokemondaywidget/MyAppWidgetProvider.kt
@@ -3,19 +3,17 @@ package com.coffeeandcookies.pokemondaywidget
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
-import android.graphics.Bitmap
 import android.util.Log
 import android.widget.RemoteViews
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.AppWidgetTarget
-import com.bumptech.glide.request.transition.Transition
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import java.util.*
 
-class MyAppWidgetProvider() : AppWidgetProvider() {
+class MyAppWidgetProvider : AppWidgetProvider() {
     override fun onUpdate(
         context: Context,
         appWidgetManager: AppWidgetManager,
@@ -26,7 +24,7 @@ class MyAppWidgetProvider() : AppWidgetProvider() {
 
             // Get the layout for the App Widget and attach an on-click listener
             // to the button
-            val views: RemoteViews = RemoteViews(context.packageName, R.layout.layout_widget_home)
+            val views = RemoteViews(context.packageName, R.layout.layout_widget_home)
 
             getPokemonDay(views, appWidgetManager, appWidgetId, context)
 
@@ -35,11 +33,12 @@ class MyAppWidgetProvider() : AppWidgetProvider() {
         }
     }
 
-
     private fun getPokemonDay(
-        views: RemoteViews, appWidgetManager: AppWidgetManager, appWidgetId: Int, context: Context
-    )
-    {
+        views: RemoteViews,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        context: Context
+    ) {
         val calendar: Calendar = Calendar.getInstance()
         val day: Int = calendar.get(Calendar.DAY_OF_YEAR)
 
@@ -51,39 +50,33 @@ class MyAppWidgetProvider() : AppWidgetProvider() {
                 if (response.isSuccessful) {
                     Log.d("pokemonapi", "Pokémon del día \n${response.body().toString()}")
 
-                    val text =
-                        "Pokémon del día \n #${response.body()?.id} - ${response.body()?.name}"
+                    val text = "Pokémon del día \n #${response.body()?.id} - ${response.body()?.name}"
 
                     views.setTextViewText(R.id.textView_pokemon_name, text)
 
-                    val awt: AppWidgetTarget = object : AppWidgetTarget(
+                    val awt = object : AppWidgetTarget(
                         context.applicationContext,
-                        R.id.imageView_pokemon_front, views, appWidgetId
-                    ) {
-                        override fun onResourceReady(
-                            resource: Bitmap,
-                            transition: Transition<in Bitmap>?
-                        ) {
-                            super.onResourceReady(resource, transition)
-                        }
-                    }
+                        R.id.imageView_pokemon_front,
+                        views,
+                        appWidgetId
+                    ) {}
 
-                    var options =
-                        RequestOptions().override(700, 700).placeholder(R.mipmap.ic_launcher).error(
-                            R.mipmap.ic_launcher
-                        )
+                    val options = RequestOptions()
+                        .override(700, 700)
+                        .placeholder(R.mipmap.ic_launcher)
+                        .error(R.mipmap.ic_launcher)
 
-                    Glide.with(context.applicationContext).asBitmap()
-                        .load(response.body()?.sprites?.front_default).apply(
-                        options
-                    ).into(awt)
+                    Glide.with(context.applicationContext)
+                        .asBitmap()
+                        .load(response.body()?.sprites?.front_default)
+                        .apply(options)
+                        .into(awt)
 
                     appWidgetManager.updateAppWidget(appWidgetId, views)
                 }
             }
 
-            override fun onFailure(call: Call<Pokemon>, t: Throwable) {
-            }
+            override fun onFailure(call: Call<Pokemon>, t: Throwable) {}
         })
     }
 }


### PR DESCRIPTION
¡Hola!

Aporto este pequeño Pull Request para corregir algunos _warnings_ que el IDE estaba dando en el código y dar un poquito más de estilo a algunas partes del código.

Se corrigieron los siguientes warnings:

- `class MyAppWidgetProvider() ...` -> `Remove empty primary constructor`

Si el constructor no recibe parámetros no hace falta agregar los paréntesis.

- `val views : RemoteViews ...` -> `Explicitly given type is redundant here`

Resulta redundante declarar el tipo de la variable si justo después del `=` se instancia un tipo concreto.

- `var options = ...` -> `Variable is never modified and can be declared immutable using val`

Esta variable debía ser inmutable, puesto que se inicializaba y nunca más se asignaba un valor distinto a ella.

- `override fun onResourceReady( ...` -> `Redundant overriding method`

Esta función lo único que hacía era llamar a la superimplementación, por lo cual resultaba innecesaria.

Como resultado de estos refactors resultan innecesarios los imports que se eliminaron.

¡Saludos y _happy coding_!
